### PR TITLE
Fix clicker economy and layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -826,6 +826,8 @@ class ClickPooUltimate {
         this.gameState.manualClicks++;
         this.gameState.xp += finalPower;
         this.gameState.profileXP += finalPower;
+        this.gameState.coins += 1;
+        this.gameState.totalCoinsEarned += 1;
 
         // Suivi des clics pour CPS
         this.gameState.recentClicks.push(currentTime);
@@ -1083,6 +1085,8 @@ class ClickPooUltimate {
             this.gameState.xp += finalPoints;
             this.gameState.profileXP += finalPoints;
             this.gameState.totalClicks++;
+            this.gameState.coins += 1;
+            this.gameState.totalCoinsEarned += 1;
             
             // Optimisation : cache la position du bouton (mise à jour toutes les 2 secondes)
             const now = Date.now();

--- a/style.css
+++ b/style.css
@@ -4061,3 +4061,8 @@ body, html {
   margin-bottom: 16px;
   filter: drop-shadow(3px 3px 0 rgba(0, 0, 0, 0.2));
 }
+/* Ensure screens fit within a single viewport */
+html, body { height: 100%; overflow: hidden; }
+.screen.active { height: 100vh; }
+.nav-icon, .back-icon { image-rendering: pixelated; }
+


### PR DESCRIPTION
## Summary
- add coin reward on each manual and auto click
- ensure game screens fit a single viewport
- pixelate navigation icons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d81fe1fb4832caa078f79693a6395